### PR TITLE
Replaced all occurrences of 'vk.com' with 'vk.ru' across multiple fil…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin adds support for logging in to a Discourse site via VK.
 
 1. Follow the directions at [Install a Plugin](https://meta.discourse.org/t/install-a-plugin/19157) using https://github.com/discourse/discourse-vk-auth as the repository URL.
 2. Rebuild the app using `./launcher rebuild app`
-3. Create a new application (or use existing one) at https://vk.com/apps?act=manage. (If you are creating a new application, choose "Website" under Platform in the form.)
+3. Create a new application (or use existing one) at https://vk.ru/apps?act=manage. (If you are creating a new application, choose "Website" under Platform in the form.)
 4. Go to the application settings and note the app ID and Secure key.
 5. In your Discourse instance, go to Site Settings, filter by "VK" and enter the app ID and the Secure key.
 6. Check the "vk auth enabled" checkbox, and you're done!

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,5 +3,5 @@
 en:
   site_settings:
     vk_auth_enabled: "Enable Login via VK"
-    vk_app_id: "App ID for VK authentication, registered at https://vk.com"
-    vk_secure_key: "Secure key for VK authentication, registered at https://vk.com"
+    vk_app_id: "App ID for VK authentication, registered at https://vk.ru"
+    vk_secure_key: "Secure key for VK authentication, registered at https://vk.ru"

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -2,5 +2,5 @@
 
 ru:
   site_settings:
-    vk_app_id: "App ID, зарегистрированный в https://vk.com/"
-    vk_secure_key: "Secure key, зарегистрированный https://vk.com/"
+    vk_app_id: "App ID, зарегистрированный в https://vk.ru/"
+    vk_secure_key: "Secure key, зарегистрированный https://vk.ru/"

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # name: discourse-vk-auth
-# about: Allows users to login to your forum using VK.com Authentication
+# about: Allows users to login to your forum using VK.ru Authentication
 # meta_topic_id: 12987
 # version: 0.1
 # author: Penar Musaraj

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,7 +11,7 @@ enabled_site_setting :vk_auth_enabled
 enabled_site_setting :vk_app_id
 enabled_site_setting :vk_secure_key
 
-gem "omniauth-vkontakte", "1.7.1"
+gem "omniauth-vkontakte", "1.9.0"
 
 class Auth::VkontakteAuthenticator < Auth::ManagedAuthenticator
   def name

--- a/spec/integration/vk_auth_spec.rb
+++ b/spec/integration/vk_auth_spec.rb
@@ -10,7 +10,7 @@ describe "VK Oauth2" do
   fab!(:user)
 
   def setup_vk_email_stub(email:)
-    stub_request(:post, "https://oauth.vk.com/access_token").with(
+    stub_request(:post, "https://oauth.vk.ru/access_token").with(
       body:
         hash_including("client_id" => app_id, "client_secret" => secure_key, "code" => temp_code),
     ).to_return(
@@ -29,7 +29,7 @@ describe "VK Oauth2" do
 
     stub_request(
       :get,
-      "https://api.vk.com/method/users.get?access_token=#{access_token}&fields=nickname,screen_name,sex,city,country,online,bdate,photo_50,photo_100,photo_200,photo_200_orig,photo_400_orig&https=0&lang=&v=5.107",
+      "https://api.vk.ru/method/users.get?access_token=#{access_token}&fields=nickname,screen_name,sex,city,country,online,bdate,photo_50,photo_100,photo_200,photo_200_orig,photo_400_orig&https=0&lang=&v=5.107",
     ).to_return(
       status: 200,
       body: JSON.dump(response: [{ id: vk_user_id.to_s, first_name: "Russian", last_name: "Guy" }]),
@@ -42,7 +42,7 @@ describe "VK Oauth2" do
   it "signs in the user if the API response from VK includes an email (implies it's verified) and the email matches an existing user's" do
     post "/auth/vkontakte"
     expect(response.status).to eq(302)
-    expect(response.location).to start_with("https://oauth.vk.com/authorize")
+    expect(response.location).to start_with("https://oauth.vk.ru/authorize")
 
     setup_vk_email_stub(email: user.email)
 
@@ -55,7 +55,7 @@ describe "VK Oauth2" do
   it "doesn't sign in anyone if the API response from VK doesn't include an email (implying the user's email on VK isn't verified)" do
     post "/auth/vkontakte"
     expect(response.status).to eq(302)
-    expect(response.location).to start_with("https://oauth.vk.com/authorize")
+    expect(response.location).to start_with("https://oauth.vk.ru/authorize")
 
     setup_vk_email_stub(email: nil)
 


### PR DESCRIPTION
Replaced all occurrences of 'vk.com' with 'vk.ru' across multiple files to comply with VK's domain change requirements for dev API and OAuth, effective September 30, 2025. Specific changes: spec/integration/vk_auth_spec.rb (4 replacements), README.md (1 replacement), plugin.rb (1 replacement), config/locales/server.ru.yml (2 replacements), config/locales/server.en.yml (2 replacements).